### PR TITLE
Feature/enrichedgraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-core"
-version = "0.0.1a9"
+version = "0.0.1a10"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-core"
-version = "0.0.1a10"
+version = "0.0.1a11"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"},

--- a/src/shieldx_core/dtos/__init__.py
+++ b/src/shieldx_core/dtos/__init__.py
@@ -165,6 +165,12 @@ class TriggersTriggersDTO(BaseModel):
     trigger_parent_id: str
     trigger_child_id: str
 
+class DeploymentInfoDTO(BaseModel):
+    """Información de red necesaria para ejecutar un objeto activo."""
+    host: str
+    req_res_port: int
+    pubsub_port: int
+
 class RuleTargetDTO(BaseModel):
     alias: str
     axo_bucket_id: str
@@ -183,12 +189,14 @@ class NodeDTO(BaseModel):
     name: Optional[str] = None
     rule: Optional[RuleDTO] = None
     params: Optional[ParamsDTO] = None
-    sink_bucket_id: Optional[str] = None  # para Buckets
+    deployment_info: Optional[DeploymentInfoDTO] = None
 
 class EdgeDTO(BaseModel):
     from_: str = Field(..., alias="from")
     to: str
 
-class GraphSpecDTO(BaseModel):
+
+class EnrichedGraphSpecDTO(BaseModel):
+    
     vertices: List[NodeDTO]
     edges: List[EdgeDTO] = []

--- a/src/shieldx_core/dtos/__init__.py
+++ b/src/shieldx_core/dtos/__init__.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel,Field
-from typing import Any, Optional,Dict
+from typing import Any, Optional,Dict,List
 from datetime import datetime,timezone
 
 class MessageWithIDDTO(BaseModel):
@@ -164,3 +164,31 @@ class TriggerUpdateDTO(BaseModel):
 class TriggersTriggersDTO(BaseModel):
     trigger_parent_id: str
     trigger_child_id: str
+
+class RuleTargetDTO(BaseModel):
+    alias: str
+    axo_bucket_id: str
+    axo_endpoint_id: str
+
+class RuleDTO(BaseModel):
+    target: RuleTargetDTO
+
+class ParamsDTO(BaseModel):
+    init: Optional[Dict[str, str]] = None
+    call: Optional[Dict[str, str]] = None
+
+class NodeDTO(BaseModel):
+    id: str
+    type: str  # "ActiveObject" | "Bucket"
+    name: Optional[str] = None
+    rule: Optional[RuleDTO] = None
+    params: Optional[ParamsDTO] = None
+    sink_bucket_id: Optional[str] = None  # para Buckets
+
+class EdgeDTO(BaseModel):
+    from_: str = Field(..., alias="from")
+    to: str
+
+class GraphSpecDTO(BaseModel):
+    vertices: List[NodeDTO]
+    edges: List[EdgeDTO] = []


### PR DESCRIPTION
**Descripción:**

Este PR introduce el nuevo **EnrichedGraphSpecDTO**, una estructura ligera y tipada que representa el grafo enriquecido utilizado durante la ejecución de coreografías en *ShieldX*.
El objetivo es estandarizar la comunicación entre **CryptoMesh**, **ShieldX Client** y **ShieldX**, permitiendo incluir información de despliegue (host y puertos) en cada nodo del grafo.

#### 🔧 Cambios principales

* Agregado el modelo `DeploymentInfoDTO` para contener la información de red del endpoint.
* Incorporado `deployment_info` dentro de `NodeDTO` para representar nodos enriquecidos.
* Definido `EnrichedGraphSpecDTO` como contenedor del grafo completo (vértices y aristas).
* Actualizado `__init__.py` para exportar el nuevo DTO.
* Incrementada la versión del paquete a `0.0.1a11`.
